### PR TITLE
Don't declare and <-> or as complements

### DIFF
--- a/rules/complement-simplification.js
+++ b/rules/complement-simplification.js
@@ -7,8 +7,6 @@ const isRamdaMethod = ast.isRamdaMethod;
 const getName = ast.getName;
 
 const names = {
-    or: 'and',
-    and: 'or',
     T: 'F',
     F: 'T'
 };


### PR DESCRIPTION
I tried to add `nand` as function to ramda-adjunct, see https://github.com/char0n/ramda-adjunct/issues/237. When I tried to do that, eslint-plugin-ramda complaint about `complement(and)` being replaceable by `or`.

This is strictly not true for one case:

```
R.or(false, false) -> false
R.complement(R.and(false, false)) -> true
```

